### PR TITLE
Remoção de atributo desnecessário no link

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Portfólio Web</title>
-    <link rel="stylesheet" type="text/css" href="estilos.css">
+    <link rel="stylesheet" href="estilos.css">
 </head>
 </head>
 <body>


### PR DESCRIPTION
Remoção do atributo type="text/css", visto que ele não é mais necessário e é boa prática não colocar